### PR TITLE
yara: Fix include callback for compiling rules

### DIFF
--- a/scanner/yara/includestate.go
+++ b/scanner/yara/includestate.go
@@ -1,0 +1,49 @@
+package yara
+
+import (
+	"github.com/spyre-project/spyre/log"
+
+	"github.com/spf13/afero"
+
+	"io/ioutil"
+	"path/filepath"
+)
+
+// includeState tracks the current working directory of including and
+// included files. It works around a limitation in YARA's
+// YR_COMPILER_INCLUDE_CALLBACK_FUNC.
+type includeState struct {
+	fs       afero.Fs
+	cwd      string
+	included []string
+}
+
+func (is *includeState) IncludeCallback(name, filename, namespace string) []byte {
+	if filename == "" {
+		is.cwd = "/"
+	}
+	name = filepath.Join(is.cwd, name)
+	is.cwd = filepath.Dir(name)
+	if filename != "" {
+		log.Debugf("yara: init: File '%s' included from '%s'", name, filename)
+	}
+	for _, file := range is.included {
+		if name == file {
+			log.Debugf("yara: init: %s has already been included; skipping.", name)
+			return []byte{}
+		}
+	}
+	is.included = append(is.included, name)
+	f, err := is.fs.Open(name)
+	if err != nil {
+		log.Errorf("yara: init: Open %s: %v", name, err)
+		return nil
+	}
+	defer f.Close()
+	buf, err := ioutil.ReadAll(f)
+	if err != nil {
+		log.Errorf("yara: init: Read from %s: %v", name, err)
+		return nil
+	}
+	return buf
+}

--- a/scanner/yara/includestate_test.go
+++ b/scanner/yara/includestate_test.go
@@ -1,0 +1,21 @@
+package yara
+
+import (
+	"github.com/spf13/afero"
+
+	yr "github.com/hillu/go-yara"
+
+	"testing"
+)
+
+func TestInclude(t *testing.T) {
+	c, err := yr.NewCompiler()
+	if err != nil {
+		t.Fatalf("Could not create YARA compiler: %s", err)
+	}
+	is := &includeState{fs: afero.NewBasePathFs(afero.NewOsFs(), "testdata")}
+	c.SetIncludeCallback(is.IncludeCallback)
+	if err = c.AddString(`include "/a.yar"`, ""); err != nil {
+		t.Errorf("Could not parse /a.yar -> b/b.yar -> ../c.yar: %s", err)
+	}
+}

--- a/scanner/yara/testdata/a.yar
+++ b/scanner/yara/testdata/a.yar
@@ -1,0 +1,3 @@
+include "b/b.yar"
+
+rule a { condition: true }

--- a/scanner/yara/testdata/b/b.yar
+++ b/scanner/yara/testdata/b/b.yar
@@ -1,0 +1,3 @@
+include "../c.yar"
+
+rule b { condition: true }

--- a/scanner/yara/testdata/c.yar
+++ b/scanner/yara/testdata/c.yar
@@ -1,0 +1,3 @@
+include "./d/d.yar"
+
+rule c { condition: true }

--- a/scanner/yara/testdata/d/d.yar
+++ b/scanner/yara/testdata/d/d.yar
@@ -1,0 +1,1 @@
+rule d { condition: true }


### PR DESCRIPTION
YARA provides the filename (as far as it is known) to the include
callback; this may not be an abolute filename and no working directory
is tracked, so we have to track it in an includeState struct.