### PR TITLE
Use explicit formatting for start/end times

### DIFF
--- a/cmd/spyre/spyre.go
+++ b/cmd/spyre/spyre.go
@@ -59,8 +59,9 @@ func main() {
 	report.AddStringf("This is Spyre version %s, running on host %s", version, spyre.Hostname)
 	defer report.Close()
 
-	log.Infof("Scan started at %s", time.Now())
-	report.AddStringf("Scan started at %s", time.Now())
+	ts := time.Now().Format("2006-01-02 15:04:05.000 -0700 MST")
+	log.Infof("Scan started at %s", ts)
+	report.AddStringf("Scan started at %s", ts)
 
 	if err := scanner.ScanSystem(); err != nil {
 		log.Errorf("Error scanning system:: %v", err)
@@ -96,6 +97,7 @@ func main() {
 			return nil
 		})
 	}
-	log.Infof("Scan finished at %s", time.Now())
-	report.AddStringf("Scan finished at %s", time.Now())
+	ts = time.Now().Format("2006-01-02 15:04:05.000 -0700 MST")
+	log.Infof("Scan finished at %s", ts)
+	report.AddStringf("Scan finished at %s", ts)
 }


### PR DESCRIPTION
This gets rid of the monotonic clock output.