### PR TITLE
Change ProcScan interface to operate on ps.Process instead of pid

### DIFF
--- a/cmd/spyre/spyre.go
+++ b/cmd/spyre/spyre.go
@@ -118,7 +118,7 @@ func main() {
 				continue
 			}
 			log.Debugf("Scanning process %s[%d]...", exe, pid)
-			if err := scanner.ScanProc(proc.Pid()); err != nil {
+			if err := scanner.ScanProc(proc); err != nil {
 				log.Errorf("Error scanning %s[%d]: %v", exe, pid, err)
 			}
 		}

--- a/scanner/modules.go
+++ b/scanner/modules.go
@@ -3,6 +3,7 @@ package scanner
 import (
 	"github.com/spyre-project/spyre/log"
 
+	"github.com/mitchellh/go-ps"
 	"github.com/spf13/afero"
 
 	"errors"
@@ -26,11 +27,12 @@ type FileScanner interface {
 }
 
 // ProcScanner scans are run after SystemScanner scans. The ScanProc
-// ismethod is run for every process that can be accessed.
+// ismethod is run for every process that can be accessed, except for
+// Spyre itself.
 type ProcScanner interface {
 	Name() string
 	Init() error
-	ScanProc(int) error
+	ScanProc(ps.Process) error
 }
 
 var (
@@ -109,9 +111,9 @@ func ScanFile(f afero.File) (err error) {
 	return
 }
 
-func ScanProc(pid int) (err error) {
+func ScanProc(proc ps.Process) (err error) {
 	for _, s := range procScanners {
-		if e := s.ScanProc(pid); err == nil && e != nil {
+		if e := s.ScanProc(proc); err == nil && e != nil {
 			err = e
 		}
 	}


### PR DESCRIPTION
This is a more general fix for the race condition fixed in
17199e96be73a142fa45dc03a7a9da9f6ddc3141.